### PR TITLE
Issue 11: changed build command as 'build_linux' is now headless. 

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -2,9 +2,8 @@ FROM golang:1.15 AS build
 RUN apt install gcc -y
 WORKDIR /src
 COPY . .
-RUN GOOS=linux go build -tags "sqlite_foreign_keys release linux" -ldflags="-s -w" -o /usr/local/bin/yarr main.go
-RUN ls /usr/local/bin
+RUN make build_linux
 
 FROM ubuntu:20.04
-COPY --from=build /usr/local/bin/yarr /usr/bin/yarr
-ENTRYPOINT ["/usr/bin/yarr"]
+COPY --from=build /src/_output/linux/yarr /usr/bin/yarr
+ENTRYPOINT ["/usr/bin/yarr", "-addr", "0.0.0.0:7070"]


### PR DESCRIPTION
Changed build command parameter to 'build_linux' as that is now headless, and the previous build command resulted in server errors and the app not displaying. 

Also, added `addr 0.0.0.0:7070` to the start parameter so that service will accept incoming requests that arrive via Docker port forwarding (e.g. `docker run -p 7070:7070`)