### PR TITLE
Embed youtube videos on feed

### DIFF
--- a/assets/javascripts/app.js
+++ b/assets/javascripts/app.js
@@ -48,6 +48,14 @@ var sanitize = function(content, base) {
   return sanitizer.sanitize(content, {FORBID_TAGS: ['style'], FORBID_ATTR: ['style', 'class']})
 }
 
+function extensions(details, content) {
+  const ytId = details.link.match(/youtube\.com\/watch\?v=(.*)$/)[1];
+  if(ytId) {
+    content+=`<iframe width="560" height="315" src="https://www.youtube.com/embed/${ytId}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope" allowfullscreen></iframe>`;
+  }
+  return content;
+}
+
 Vue.use(VueLazyload)
 
 Vue.directive('scroll', {
@@ -214,7 +222,7 @@ var vm = new Vue({
       else if (this.itemSelectedDetails.description)
         content = this.itemSelectedDetails.description
 
-      return sanitize(content, this.itemSelectedDetails.link)
+      return extensions(this.itemSelectedDetails,sanitize(content, this.itemSelectedDetails.link))
     },
   },
   watch: {


### PR DESCRIPTION
First of all thank you for making this package, I love the app simplicity!

I used RSS with Feedly previously and my most common use case was following Youtube channels ([with this endpoint](https://www.youtube.com/feeds/videos.xml?channel_id=........)).

Youtube videos weren't embedded here so I decided to embed them, maybe it could be done better with gofeed and it's extension system but I'm still very new to Go and couldn't figure it out.