### PR TITLE
go back to the original gofeed library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /server/assets.go
-/gofeed
 /_output
 /yarr
 *.db

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.5.1
 	github.com/getlantern/systray v1.0.4
 	github.com/mattn/go-sqlite3 v1.14.0
-	github.com/mmcdole/gofeed v1.0.0
+	github.com/mmcdole/gofeed v1.1.0
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e
 )
-
-replace github.com/mmcdole/gofeed => ./gofeed

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/mattn/go-sqlite3 v1.14.0 h1:mLyGNKR8+Vv9CAU7PphKa2hkEqxxhn8i32J6FPj1/
 github.com/mattn/go-sqlite3 v1.14.0/go.mod h1:JIl7NbARA7phWnGvh0LKTyg7S9BA+6gx71ShQilpsus=
 github.com/mmcdole/gofeed v1.0.0 h1:PHqwr8fsEm8xarj9s53XeEAFYhRM3E9Ib7Ie766/LTE=
 github.com/mmcdole/gofeed v1.0.0/go.mod h1:tkVcyzS3qVMlQrQxJoEH1hkTiuo9a8emDzkMi7TZBu0=
+github.com/mmcdole/gofeed v1.1.0 h1:T2WrGLVJRV04PY2qwhEJLHCt9JiCtBhb6SmC8ZvJH08=
+github.com/mmcdole/gofeed v1.1.0/go.mod h1:PPiVwgDXLlz2N83KB4TrIim2lyYM5Zn7ZWH9Pi4oHUk=
 github.com/mmcdole/goxpp v0.0.0-20181012175147-0068e33feabf h1:sWGE2v+hO0Nd4yFU/S/mDBM5plIU8v/Qhfz41hkDIAI=
 github.com/mmcdole/goxpp v0.0.0-20181012175147-0068e33feabf/go.mod h1:pasqhqstspkosTneA62Nc+2p9SOBBYAPbnmRRWPQ0V8=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OHLH3mGKHDcjJRFFRrJa6eAM5H+CtDdOsPc=

--- a/hacking.md
+++ b/hacking.md
@@ -6,8 +6,6 @@ Install `Go >= 1.14` and `gcc`. Get the source code:
 
 ```sh
 git clone https://github.com/nkanaev/yarr.git
-git clone https://github.com/nkanaev/gofeed.git
-mv gofeed yarr
 cd yarr
 ```
 


### PR DESCRIPTION
From what I can see, there's no need to use the modified gofeed library since everything (?) has been merged to the original project.

---

I want to thank you, @nkanaev, and everyone that has contributed to this project. It's a breath of fresh air in the RSS reader world due to its simplicity.