### PR TITLE
Resolves Issue #20, Adds A GitHub Action to Auto-Publish to Docker Hub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,26 @@ on:
     tags: [v*]
 
 jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push to Docker Hub
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ secrets.DOCKERHUB_REPO }}
+          context: .
+          file: ./dockerfile
+  
   build_macos:
     name: Build for MacOS
     runs-on: macos-10.15

--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,3 @@ require (
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e
 )
-
-replace github.com/mmcdole/gofeed => ./gofeed

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ To build with Docker
 
 3. Create a data directory to store persistent yarr data `mkdir $HOME/yarr-data`
 
-4. Run `docker run -p 7070:7070 -v $HOME/yarr-data:data yarr` (You'll need to replace "$HOME" with the full path)
+4. Run `docker run -p 7070:7070 -v $HOME/yarr-data:/data/ yarr`
 
 ## credits
 

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,18 @@ Longer-term plans include a self-hosted solution for individuals.
 
 [download](https://github.com/nkanaev/yarr/releases/latest)
 
+## Building With Docker
+
+To build with Docker
+
+1. Clone this git repo to your machine and `cd` into that directory
+
+2. Run `docker build -t yarr .`
+
+3. Create a data directory to store persistent yarr data `mkdir $HOME/yarr-data`
+
+4. Run `docker run -p 7070:7070 -v $HOME/yarr-data:data yarr` (You'll need to replace "$HOME" with the full path)
+
 ## credits
 
 [Feather](http://feathericons.com/) for icons.


### PR DESCRIPTION
Resolves #20 

This pull request removes the breaking change in `go.mod` to allow Docker builds to work again. It adds a GitHub action to auto push new builds to Docker Hub with a tag of `latest`, and updates `readme.me` with Docker instructions.

For this to work for your Docker Hub account, you'll need to set three [GitHub Secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) for this repository before this action will successfully run. 

1. `DOCKERHUB_USERNAME` should be your Docker Hub username
2. `DOCKERHUB_TOKEN` should be a [Docker Hub Access Token](https://docs.docker.com/docker-hub/access-tokens/) 
3. `DOCKERHUB_REPO` should be your Docker Hub repo. In my case that was `eldridgea/yarr`. As long as the username matches, the repo doesn't have to already exist on Docker Hub, GitHub Actions will create it if necessary. 