### PR TITLE
Add workflow to publish docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,11 +86,42 @@ jobs:
         name: linux
         path: _output/linux/yarr
 
+  build_docker:
+    name: Build and push to Docker
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Login to registry
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Set output
+        id: vars
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+      - name: Push to Docker
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ github.repository }}:latest
+            ${{ github.repository }}:${{ steps.vars.outputs.tag }}
+
   create_release:
     name: Create Release
     runs-on: ubuntu-latest
     if: ${{ !contains(github.ref, 'test') }}
-    needs: [build_macos, build_windows, build_linux]
+    needs: [build_macos, build_windows, build_linux, build_docker]
     steps:
     - name: Create Release
       uses: actions/create-release@v1


### PR DESCRIPTION
Hello, first thank you for yarr, it's a pretty cool project. 

I've been using it in a headless server and I needed a Docker image, so I created this workflow which publishes new versions to Dockerhub. Right now it's published under `arsfeld/yarr`, but if you include in your project, it'll use your own username.

The only requirement is that you need to create a Dockerhub account and add the secrets `DOCKER_USERNAME` and `DOCKER_PASSWORD` to your project.

It also mimics the build for other platforms but it means it'll push to Dockerhub while the release in Github is still in draft. 