### PR TITLE
ParseRSS: accept any file with audio/ media type as podcast

### DIFF
--- a/src/parser/rss.go
+++ b/src/parser/rss.go
@@ -71,7 +71,7 @@ func ParseRSS(r io.Reader) (*Feed, error) {
 	for _, srcitem := range srcfeed.Items {
 		podcastURL := ""
 		for _, e := range srcitem.Enclosures {
-			if e.Type == "audio/mpeg" || e.Type == "audio/x-m4a" {
+			if strings.HasPrefix(e.Type, "audio/") {
 				podcastURL = e.URL
 
 				if srcitem.OrigEnclosureLink != "" && strings.Contains(podcastURL, path.Base(srcitem.OrigEnclosureLink)) {

--- a/src/parser/rss_test.go
+++ b/src/parser/rss_test.go
@@ -136,6 +136,26 @@ func TestRSSPodcast(t *testing.T) {
 	}
 }
 
+func TestRSSOpusPodcast(t *testing.T) {
+	feed, _ := Parse(strings.NewReader(`
+		<?xml version="1.0" encoding="UTF-8"?>
+		<rss version="2.0">
+			<channel>
+				<item>
+					<enclosure length="100500" type="audio/opus" url="http://example.com/audio.ext"/>
+				</item>
+			</channel>
+		</rss>
+	`))
+	have := feed.Items[0].AudioURL
+	want := "http://example.com/audio.ext"
+	if want != have {
+		t.Logf("want: %#v", want)
+		t.Logf("have: %#v", have)
+		t.FailNow()
+	}
+}
+
 // found in: https://podcast.cscript.site/podcast.xml
 func TestRSSPodcastDuplicated(t *testing.T) {
 	feed, _ := Parse(strings.NewReader(`


### PR DESCRIPTION
There are some podcasts that use `audio/opus` files (mostly as an alternative, but still), which makes the audio attachment not being displayed.

Instead of increasing the list of allowed formats (because `audio/mp3` would be quite useful on the list too), I guess it'd be better to give any `audio/` media type to the user-agent and let him worry about it. :^)