### PR TITLE
Autoselect current folder when adding a new feed

### DIFF
--- a/src/assets/index.html
+++ b/src/assets/index.html
@@ -350,7 +350,7 @@
                     </label>
                     <select class="form-control" id="feed-folder" name="folder_id" ref="newFeedFolder">
                         <option value="">---</option>
-                        <option :value="folder.id" v-for="folder in folders">{{ folder.title }}</option>
+                        <option :value="folder.id" v-for="folder in folders" :selected="folder.id === current.feed.folder_id || folder.id === current.folder.id">{{ folder.title }}</option>
                     </select>
                     <div class="mt-4" v-if="feedNewChoice.length">
                         <p class="mb-2">


### PR DESCRIPTION
This patch makes categorising new feeds a bit more intuitive: the selected folder (or feed within a folder) in the feed list will automatically  be selected when adding a new feed.