### PR TITLE
Log to console on Windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/nkanaev/yarr
 go 1.16
 
 require (
+	github.com/ffred/guitocons v0.0.0-20180103100707-e6ef37a75a5e // indirect
 	github.com/mattn/go-sqlite3 v1.14.7
 	golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420
 	golang.org/x/sys v0.0.0-20210503173754-0981d6026fa6

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/ffred/guitocons v0.0.0-20180103100707-e6ef37a75a5e h1:h+70xO+I2H1tVB5yTRbaPO+JuTTs44o8vWIcX9nhQkw=
+github.com/ffred/guitocons v0.0.0-20180103100707-e6ef37a75a5e/go.mod h1:EM9wg5H8ZTtFWm2/QsskKRrDc75gCOC6ZBthnYxbbZI=
 github.com/mattn/go-sqlite3 v1.14.7 h1:fxWBnXkxfM6sRiuH3bqJ4CfzZojMOLVc0UTsTglEghA=
 github.com/mattn/go-sqlite3 v1.14.7/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420 h1:a8jGStKg0XqKDlKqjLrXn0ioF5MH36pT7Z0BRTqLhbk=

--- a/src/main.go
+++ b/src/main.go
@@ -12,6 +12,8 @@ import (
 	"github.com/nkanaev/yarr/src/platform"
 	"github.com/nkanaev/yarr/src/server"
 	"github.com/nkanaev/yarr/src/storage"
+
+	"github.com/ffred/guitocons"
 )
 
 var Version string = "0.0"
@@ -31,6 +33,8 @@ func opt(envVar, defaultValue string) string {
 func main() {
 	var addr, db, authfile, certfile, keyfile, basepath, logfile string
 	var ver, open bool
+
+	guitocons.Guitocons()
 
 	flag.CommandLine.SetOutput(os.Stdout)
 


### PR DESCRIPTION
This uses the module http://github.com/ffred/guitocons which fixes #80 and the exe can now output to Windows console.

```
➜ _output/windows/yarr.exe -addr 0.0.0.0:7090 -db local.db
2021/11/06 21:07:37 main.go:90: using db file local.db
2021/11/06 21:07:37 main.go:137: starting server at http://0.0.0.0:7090
```

But this will probably break the build on other platforms. I'm new to Go so if you can suggest how can I structure the code so that this only affects Windows, I'd make the change.

