### PR TITLE
Fix concurrent map writes for FeedIcon cache

### DIFF
--- a/src/server/routes.go
+++ b/src/server/routes.go
@@ -177,7 +177,9 @@ func (s *Server) handleFeedIcon(c *router.Context) {
 			bytes: *(*feed).Icon,
 			etag:  etag,
 		}
+		s.cache_mutex.Lock()
 		s.cache[cachekey] = cachedat
+		s.cache_mutex.Unlock()
 	}
 
 	icon := cachedat.(feedicon)

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"log"
 	"net/http"
+	"sync"
 
 	"github.com/nkanaev/yarr/src/storage"
 	"github.com/nkanaev/yarr/src/worker"
@@ -13,6 +14,7 @@ type Server struct {
 	db     *storage.Storage
 	worker *worker.Worker
 	cache  map[string]interface{}
+	cache_mutex *sync.Mutex
 
 	BasePath string
 
@@ -30,6 +32,7 @@ func NewServer(db *storage.Storage, addr string) *Server {
 		Addr:   addr,
 		worker: worker.NewWorker(db),
 		cache:  make(map[string]interface{}),
+		cache_mutex: &sync.Mutex{},
 	}
 }
 


### PR DESCRIPTION
I suppose the mutex should resolve cache concurent writes.. linked issue report https://github.com/nkanaev/yarr/issues/101
