### PR TITLE
Run go fmt

### DIFF
--- a/src/parser/feed_test.go
+++ b/src/parser/feed_test.go
@@ -7,9 +7,9 @@ import (
 )
 
 func TestSniff(t *testing.T) {
-	testcases := []struct{
+	testcases := []struct {
 		input string
-		want feedProbe
+		want  feedProbe
 	}{
 		{
 			`<?xml version="1.0"?><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"></rdf:RDF>`,

--- a/src/server/router/router.go
+++ b/src/server/router/router.go
@@ -32,9 +32,9 @@ func (r *Router) Use(h Handler) {
 }
 
 func (r *Router) For(path string, handler Handler) {
-    chain := make([]Handler, 0)
-    chain = append(chain, r.middle...)
-    chain = append(chain, handler)
+	chain := make([]Handler, 0)
+	chain = append(chain, r.middle...)
+	chain = append(chain, handler)
 
 	x := Route{}
 	x.regex = routeRegexp(path)

--- a/src/server/routes.go
+++ b/src/server/routes.go
@@ -340,7 +340,7 @@ func (s *Server) handleItemList(c *router.Context) {
 			items = items[:perPage]
 		}
 		c.JSON(http.StatusOK, map[string]interface{}{
-			"list": items,
+			"list":     items,
 			"has_more": hasMore,
 		})
 	} else if c.Req.Method == "PUT" {

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -10,10 +10,10 @@ import (
 )
 
 type Server struct {
-	Addr   string
-	db     *storage.Storage
-	worker *worker.Worker
-	cache  map[string]interface{}
+	Addr        string
+	db          *storage.Storage
+	worker      *worker.Worker
+	cache       map[string]interface{}
 	cache_mutex *sync.Mutex
 
 	BasePath string
@@ -28,10 +28,10 @@ type Server struct {
 
 func NewServer(db *storage.Storage, addr string) *Server {
 	return &Server{
-		db:     db,
-		Addr:   addr,
-		worker: worker.NewWorker(db),
-		cache:  make(map[string]interface{}),
+		db:          db,
+		Addr:        addr,
+		worker:      worker.NewWorker(db),
+		cache:       make(map[string]interface{}),
 		cache_mutex: &sync.Mutex{},
 	}
 }

--- a/src/storage/item_test.go
+++ b/src/storage/item_test.go
@@ -291,7 +291,7 @@ func TestDeleteOldItems(t *testing.T) {
 		})
 	}
 	db.CreateItems(items)
-	
+
 	db.SetFeedSize(feed.Id, itemsKeepSize)
 	var feedSize int
 	err := db.db.QueryRow(
@@ -302,7 +302,7 @@ func TestDeleteOldItems(t *testing.T) {
 	}
 	if feedSize != itemsKeepSize {
 		t.Fatalf(
-			"expected feed size to get updated\nwant: %d\nhave: %d", 
+			"expected feed size to get updated\nwant: %d\nhave: %d",
 			itemsKeepSize+extraItems,
 			feedSize,
 		)


### PR DESCRIPTION
This patch is the result of running `go fmt ./...` with Go v1.16.15.