### PR TITLE
Fix Makefile build targets

### DIFF
--- a/makefile
+++ b/makefile
@@ -8,23 +8,23 @@ GO_LDFLAGS := $(GO_LDFLAGS) -X 'main.Version=$(VERSION)' -X 'main.GitHash=$(GITH
 
 build_default:
 	mkdir -p _output
-	go build -tags "sqlite_foreign_keys release" -ldflags="$(GO_LDFLAGS)" -o _output/yarr src/main.go
+	go build -tags "sqlite_foreign_keys release" -ldflags="$(GO_LDFLAGS)" -o _output/yarr ./src
 
 build_macos:
 	mkdir -p _output/macos
-	GOOS=darwin GOARCH=amd64 go build -tags "sqlite_foreign_keys release macos" -ldflags="$(GO_LDFLAGS)" -o _output/macos/yarr src/main.go
+	GOOS=darwin GOARCH=amd64 go build -tags "sqlite_foreign_keys release macos" -ldflags="$(GO_LDFLAGS)" -o _output/macos/yarr ./src
 	cp src/platform/icon.png _output/macos/icon.png
 	go run bin/package_macos.go -outdir _output/macos -version "$(VERSION)"
 
 build_linux:
 	mkdir -p _output/linux
-	GOOS=linux GOARCH=amd64 go build -tags "sqlite_foreign_keys release linux" -ldflags="$(GO_LDFLAGS)" -o _output/linux/yarr src/main.go
+	GOOS=linux GOARCH=amd64 go build -tags "sqlite_foreign_keys release linux" -ldflags="$(GO_LDFLAGS)" -o _output/linux/yarr ./src
 
 build_windows:
 	mkdir -p _output/windows
 	go run bin/generate_versioninfo.go -version "$(VERSION)" -outfile src/platform/versioninfo.rc
 	windres -i src/platform/versioninfo.rc -O coff -o src/platform/versioninfo.syso
-	GOOS=windows GOARCH=amd64 go build -tags "sqlite_foreign_keys release windows" -ldflags="$(GO_LDFLAGS) -H windowsgui" -o _output/windows/yarr.exe src/main.go
+	GOOS=windows GOARCH=amd64 go build -tags "sqlite_foreign_keys release windows" -ldflags="$(GO_LDFLAGS) -H windowsgui" -o _output/windows/yarr.exe ./src
 
 serve:
 	go run -tags "sqlite_foreign_keys" src/main.go -db local.db


### PR DESCRIPTION
Before this patch, the Make build targets referred to a single Go file
to be built: `src/main.gp`. However after multiple files were added to
the ./src/ package, the make command failed.

This patch changes the Make targets so that they build the whole main
package at `/src`, rather than one single `main.go` file.