### PR TITLE
Set auth without authfile

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -47,7 +47,7 @@ func parseAuthfile(authfile io.Reader) (username, password string, err error) {
 func main() {
 	platform.FixConsoleIfNeeded()
 
-	var addr, db, authfile, certfile, keyfile, basepath, logfile string
+	var addr, db, authfile, auth, certfile, keyfile, basepath, logfile string
 	var ver, open bool
 
 	flag.CommandLine.SetOutput(os.Stdout)
@@ -62,7 +62,8 @@ func main() {
 
 	flag.StringVar(&addr, "addr", opt("YARR_ADDR", "127.0.0.1:7070"), "address to run server on")
 	flag.StringVar(&basepath, "base", opt("YARR_BASE", ""), "base path of the service url")
-	flag.StringVar(&authfile, "auth-file", opt("YARR_AUTHFILE", ""), "`path` to a file containing username:password")
+	flag.StringVar(&authfile, "auth-file", opt("YARR_AUTHFILE", ""), "`path` to a file containing username:password. Takes precedence over --auth (or YARR_AUTH)")
+	flag.StringVar(&auth, "auth", opt("YARR_AUTH", ""), "string with username and password in the format `username:password`")
 	flag.StringVar(&certfile, "cert-file", opt("YARR_CERTFILE", ""), "`path` to cert file for https")
 	flag.StringVar(&keyfile, "key-file", opt("YARR_KEYFILE", ""), "`path` to key file for https")
 	flag.StringVar(&db, "db", opt("YARR_DB", ""), "storage file `path`")
@@ -113,6 +114,11 @@ func main() {
 		username, password, err = parseAuthfile(f)
 		if err != nil {
 			log.Fatal("Failed to parse auth file: ", err)
+		}
+	} else if auth != "" {
+		username, password, err = parseAuthfile(strings.NewReader(auth))
+		if err != nil {
+			log.Fatal("Failed to parse auth literal: ", err)
 		}
 	}
 


### PR DESCRIPTION
With this patch, it is possible to pass username and password directly
on the command line with:

```shell
yarr --auth 'username:password'
```

The corresponding environment variable comes handy with containers:
```shell
YARR_AUTH='username:password' yarr
```