### PR TITLE
fix linux download instruction

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ Download `yarr-*-windows64.zip`, unzip it, open `yarr.exe`
 
 ### linux
 
-Download `yarr-*-windows`, unzip it, place `yarr` in `$HOME/.local/bin`
+Download `yarr-*-linux64.zip`, unzip it, place `yarr` in `$HOME/.local/bin`
 and run [the script](etc/install-linux.sh).
 
 For self-hosting, see `yarr -h` for auth, tls & server configuration flags.


### PR DESCRIPTION
The instruction for downloading yarr for linux told the user to download yar-\*-windows which is incorrect. The Linux package on the releases page is yarr-\*-linux64.zip.