### PR TITLE
Add manifest.json for better mobile integration

### DIFF
--- a/src/assets/index.html
+++ b/src/assets/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="./static/stylesheets/app.css">
     <link rel="icon" href="./static/graphicarts/favicon.svg" type="image/svg+xml">
     <link rel="alternate icon" href="./static/graphicarts/favicon.png" type="image/png">
+    <link rel="manifest" href="./manifest.json" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <script>
         window.app = window.app || {}

--- a/src/server/routes.go
+++ b/src/server/routes.go
@@ -39,6 +39,7 @@ func (s *Server) handler() http.Handler {
 	}
 
 	r.For("/", s.handleIndex)
+	r.For("/manifest.json", s.handleManifest)
 	r.For("/static/*path", s.handleStatic)
 	r.For("/api/status", s.handleStatus)
 	r.For("/api/folders", s.handleFolderList)
@@ -74,6 +75,24 @@ func (s *Server) handleStatic(c *router.Context) {
 		return
 	}
 	http.StripPrefix(s.BasePath+"/static/", http.FileServer(http.FS(assets.FS))).ServeHTTP(c.Out, c.Req)
+}
+
+func (s *Server) handleManifest(c *router.Context) {
+	c.JSON(http.StatusOK, map[string]interface{}{
+		"$schema":     "https://json.schemastore.org/web-manifest-combined.json",
+		"name":        "yarr!",
+		"short_name":  "yarr",
+		"description": "yet another rss reader",
+		"display":     "standalone",
+		"start_url":   s.BasePath,
+		"icons": []map[string]interface{}{
+			{
+				"src":   s.BasePath + "/static/graphicarts/favicon.png",
+				"sizes": "64x64",
+				"type":  "image/png",
+			},
+		},
+	})
 }
 
 func (s *Server) handleStatus(c *router.Context) {


### PR DESCRIPTION
manifest.json allows yarr to run in a more app-like mode on mobile devices.

More info here: https://developer.mozilla.org/en-US/docs/Web/Manifest