### PR TITLE
Firefox uses altKey to switch tabs

### DIFF
--- a/src/assets/javascripts/key.js
+++ b/src/assets/javascripts/key.js
@@ -179,7 +179,7 @@ function isTextBox(element) {
 document.addEventListener('keydown',function(event) {
   // Ignore while focused on text or
   // when using modifier keys (to not clash with browser behaviour)
-  if (isTextBox(event.target) || event.metaKey || event.ctrlKey) {
+  if (isTextBox(event.target) || event.metaKey || event.ctrlKey || event.altKey) {
     return
   }
   var keybindFunction = keybindings[event.key]


### PR DESCRIPTION
Firefox browser uses Alt key to switch tabs.