### PR TITLE
fix golang download url for arm platform.

### DIFF
--- a/dockerfile.arm
+++ b/dockerfile.arm
@@ -12,9 +12,9 @@ RUN env DEBIAN_FRONTEND=noninteractive \
     apt install -y qemu-user qemu-user-static
 
 # Install Golang
-RUN wget --quiet https://go.dev/dl/go1.18.2.linux-amd64.tar.gz && \
+RUN wget --quiet https://go.dev/dl/go1.18.2.linux-arm64.tar.gz && \
     rm -rf /usr/local/go && \
-    tar -C /usr/local -xzf go1.18.2.linux-amd64.tar.gz
+    tar -C /usr/local -xzf go1.18.2.linux-arm64.tar.gz
 ENV PATH=$PATH:/usr/local/go/bin
 
 # Copy source code


### PR DESCRIPTION
I tried to build docker image on my macbook m1x laptop but needed to fix the golang download url first.