### PR TITLE
add browser history support

### DIFF
--- a/src/assets/javascripts/app.js
+++ b/src/assets/javascripts/app.js
@@ -184,6 +184,10 @@ Vue.component('relative-time', {
 
 var vm = new Vue({
   created: function() {
+    window.addEventListener('popstate', (event) => {
+      vm.itemSelected = event.state
+    })
+
     this.refreshStats()
       .then(this.refreshFeeds.bind(this))
       .then(this.refreshItems.bind(this, false))
@@ -319,6 +323,7 @@ var vm = new Vue({
     },
     'itemSelected': function(newVal, oldVal) {
       this.itemSelectedReadability = ''
+      window.history.pushState(newVal, "")
       if (newVal === null) {
         this.itemSelectedDetails = null
         return


### PR DESCRIPTION
Adds support for the browser history API. This way, you can navigate yarr using the browser forwards and backwards buttons, especially useful on mobile android, where going back now actually takes you back in the app instead of taking you to whatever page you were on before.
