### PR TITLE
add make for arm7

### DIFF
--- a/build.md
+++ b/build.md
@@ -11,6 +11,9 @@ Then run one of the corresponding commands:
     make build_linux    # -> _output/linux/yarr
     make build_windows  # -> _output/windows/yarr.exe
 
+    # create an executable for Raspberry Pi
+    make build_linux_arm7  # -> _output/linux/yarr
+
     # host-specific cli version (no gui)
     make build_default  # -> _output/yarr
 

--- a/makefile
+++ b/makefile
@@ -20,6 +20,10 @@ build_linux:
 	mkdir -p _output/linux
 	GOOS=linux GOARCH=amd64 go build -tags "sqlite_foreign_keys release linux" -ldflags="$(GO_LDFLAGS)" -o _output/linux/yarr src/main.go
 
+build_linux_arm7:
+	mkdir -p _output/linux
+	CGO_ENABLED=1 GOOS=linux GOARCH=arm GOARM=7 go build -tags "sqlite_foreign_keys release linux" -ldflags="$(GO_LDFLAGS)" -o _output/linux/yarr src/main.go
+
 build_windows:
 	mkdir -p _output/windows
 	go run bin/generate_versioninfo.go -version "$(VERSION)" -outfile src/platform/versioninfo.rc

--- a/src/assets/index.html
+++ b/src/assets/index.html
@@ -9,6 +9,7 @@
     <link rel="alternate icon" href="./static/graphicarts/favicon.png" type="image/png">
     <link rel="manifest" href="./manifest.json" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="referrer" content="never">
     <script>
         window.app = window.app || {}
         window.app.settings = {% .settings %}


### PR DESCRIPTION
The documentation was somewhat misleading to me, as I initially believed that we had to build a Docker image for the Raspberry Pi.
Actually we can easily compile a 9.5MB binary rather than the 1.9GB docker image.

```
$ go version
go version go1.20.1 linux/arm
$ make build_linux_arm7
$ sudo cp _output/linux/yarr /usr/local/bin/
```