### PR TITLE
fix item order

### DIFF
--- a/src/storage/item.go
+++ b/src/storage/item.go
@@ -76,7 +76,7 @@ func (s *Storage) CreateItems(items []Item) bool {
 		return false
 	}
 
-	now := time.Now()
+	now := time.Now().UTC()
 
 	for _, item := range items {
 		_, err = tx.Exec(`
@@ -85,7 +85,7 @@ func (s *Storage) CreateItems(items []Item) bool {
 				content, image, podcast_url,
 				date_arrived, status
 			)
-			values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			values (?, ?, ?, ?, strftime('%Y-%m-%d %H:%M:%f', ?), ?, ?, ?, ?, ?)
 			on conflict (feed_id, guid) do nothing`,
 			item.GUID, item.FeedId, item.Title, item.Link, item.Date,
 			item.Content, item.ImageURL, item.AudioURL,
@@ -343,7 +343,7 @@ func (s *Storage) DeleteOldItems() {
 			feedId,
 			STARRED,
 			limit,
-			time.Now().Add(-time.Hour*time.Duration(24*itemsKeepDays)),
+			time.Now().UTC().Add(-time.Hour*time.Duration(24*itemsKeepDays)),
 		)
 		if err != nil {
 			log.Print(err)

--- a/src/storage/item_test.go
+++ b/src/storage/item_test.go
@@ -276,7 +276,7 @@ func TestMarkItemsRead(t *testing.T) {
 func TestDeleteOldItems(t *testing.T) {
 	extraItems := 10
 
-	now := time.Now()
+	now := time.Now().UTC()
 	db := testDB()
 	feed := db.CreateFeed("feed", "", "", "http://test.com/feed11.xml", nil)
 

--- a/src/storage/migration.go
+++ b/src/storage/migration.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"time"
 )
 
 var migrations = []func(*sql.Tx) error{
@@ -14,6 +15,7 @@ var migrations = []func(*sql.Tx) error{
 	m05_move_description_to_content,
 	m06_fill_missing_dates,
 	m07_add_feed_size,
+	m08_normalize_datetime,
 }
 
 var maxVersion = int64(len(migrations))
@@ -269,5 +271,26 @@ func m07_add_feed_size(tx *sql.Tx) error {
 		);
 	`
 	_, err := tx.Exec(sql)
+	return err
+}
+
+func m08_normalize_datetime(tx *sql.Tx) error {
+	rows, err := tx.Query(`select id, date_arrived from items;`)
+	if err != nil {
+		return err
+	}
+	for rows.Next() {
+		var id int64
+		var dateArrived time.Time
+		err = rows.Scan(&id, &dateArrived)
+		if err != nil {
+			return err
+		}
+		_, err = tx.Exec(`update items set date_arrived = ? where id = ?;`, dateArrived.UTC(), id)
+		if err != nil {
+			return err
+		}
+	}
+	_, err = tx.Exec(`update items set date = strftime('%Y-%m-%d %H:%M:%f', date);`)
 	return err
 }


### PR DESCRIPTION
mattn/go-sqlite3 formats and binds `time.Time` parameters as `TEXT` values with time zones[^1] like `2022-12-16 00:08:21+00:00` and `2022-12-17 22:39:04+08:00` to queries which makes items with different time zones out of order in `storage.ListItems`. As <https://pkg.go.dev/time> mentioned, _the RFC3339Nano format removes trailing zeros from the seconds field and thus may not sort correctly once formatted_, `.999999999` in the layout string used by mattn/go-sqlite3 also results in the same problem. As RSS does not use the fractional part of seconds in dates[^2][^3] and Atom uses at most 1 decimal place of the fractional part of seconds in dates[^4], use `strftime('%Y-%m-%d %H:%M:%f', ?)` function to format incoming `date` field values in SQLite should be enough, though I found some Atom feeds using 3 decimal places of the fractional part of seconds in dates, not sure if I missed something. The `date_arrived` field values are always constructed by the Go program with full accuracy, so I just make them stored in UTC uniformly.

Feed links for reproduction:

- https://rsshub.app/ithome/soft
- https://linux.cn/rss.xml

[^1]: https://github.com/mattn/go-sqlite3/issues/748#issuecomment-538643131
[^2]: https://web.resource.org/rss/1.0/spec
[^3]: https://www.rssboard.org/rss-specification#optionalChannelElements
[^4]: https://www.rfc-editor.org/rfc/rfc4287#section-3.3
