### PR TITLE
Update minimum required Go version to 1.17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build_macos:
     name: Build for MacOS
-    runs-on: macos-10.15
+    runs-on: macos-13
     steps:
     - name: "Checkout"
       uses: actions/checkout@v2
@@ -34,7 +34,7 @@ jobs:
 
   build_windows:
     name: Build for Windows
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
     - name: "Checkout"
       uses: actions/checkout@v2
@@ -61,7 +61,7 @@ jobs:
 
   build_linux:
     name: Build for Linux
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - name: "Checkout"
       uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     - name: "Setup Go"
       uses: actions/setup-go@v2
       with:
-        go-version: '^1.16'
+        go-version: '^1.17'
     - name: Cache Go Modules
       uses: actions/cache@v2
       with:
@@ -43,7 +43,7 @@ jobs:
     - name: "Setup Go"
       uses: actions/setup-go@v2
       with:
-        go-version: '^1.16'
+        go-version: '^1.17'
     - name: Cache Go Modules
       uses: actions/cache@v2
       with:
@@ -70,7 +70,7 @@ jobs:
     - name: "Setup Go"
       uses: actions/setup-go@v2
       with:
-        go-version: '^1.16'
+        go-version: '^1.17'
     - name: Cache Go Modules
       uses: actions/cache@v2
       with:

--- a/build.md
+++ b/build.md
@@ -1,6 +1,6 @@
 ## Compilation
 
-Install `Go >= 1.16` and `GCC`. Get the source code:
+Install `Go >= 1.17` and `GCC`. Get the source code:
 
     git clone https://github.com/nkanaev/yarr.git
 

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,11 @@
 module github.com/nkanaev/yarr
 
-go 1.16
+go 1.17
 
 require (
 	github.com/mattn/go-sqlite3 v1.14.7
 	golang.org/x/net v0.8.0
 	golang.org/x/sys v0.6.0
 )
+
+require golang.org/x/text v0.8.0 // indirect

--- a/vendor/github.com/mattn/go-sqlite3/go.mod
+++ b/vendor/github.com/mattn/go-sqlite3/go.mod
@@ -1,3 +1,0 @@
-module github.com/mattn/go-sqlite3
-
-go 1.12

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,16 +1,17 @@
 # github.com/mattn/go-sqlite3 v1.14.7
-## explicit
+## explicit; go 1.12
 github.com/mattn/go-sqlite3
 # golang.org/x/net v0.8.0
-## explicit
+## explicit; go 1.17
 golang.org/x/net/html
 golang.org/x/net/html/atom
 golang.org/x/net/html/charset
 # golang.org/x/sys v0.6.0
-## explicit
+## explicit; go 1.17
 golang.org/x/sys/internal/unsafeheader
 golang.org/x/sys/windows
 # golang.org/x/text v0.8.0
+## explicit; go 1.17
 golang.org/x/text/encoding
 golang.org/x/text/encoding/charmap
 golang.org/x/text/encoding/htmlindex


### PR DESCRIPTION
With the modules currently vendored, the minimum required version of Go is 1.17. Additionally, I updated the GitHub Actions workflow to make use of some recent images. Otherwise, the build would not even run for Linux and macOS (the images specified were not available any longer).

The changes in the vendor directory are required due to the increase of the Go version.