### PR TITLE
fix the error of missing some GLIBC libs

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,9 +1,9 @@
 VERSION=2.4
 GITHASH=$(shell git rev-parse --short=8 HEAD)
 
-CGO_ENABLED=1
+CGO_ENABLED=0
 
-GO_LDFLAGS  = -s -w
+GO_LDFLAGS  = -linkmode 'external' -extldflags '-static' -s -w
 GO_LDFLAGS := $(GO_LDFLAGS) -X 'main.Version=$(VERSION)' -X 'main.GitHash=$(GITHASH)'
 
 build_default:


### PR DESCRIPTION
I have modified values of CGO_ENABLE and GO_LDFLAGS to solve issue [155](https://github.com/nkanaev/yarr/issues/155). now running `ldd yarr` shows it don`t have any dependencies.
![fixed](https://github.com/nkanaev/yarr/assets/21240907/b3e8ed98-a6ee-4c0b-8d72-da1d4950253c)
