### PR TITLE
Pull atom xhtml title from nested elements

### DIFF
--- a/src/parser/atom.go
+++ b/src/parser/atom.go
@@ -47,6 +47,8 @@ type atomLinks []atomLink
 func (a *atomText) Text() string {
 	if a.Type == "html" {
 		return htmlutil.ExtractText(a.Data)
+	} else if a.Type == "xhtml" {
+		return htmlutil.ExtractText(a.XML)
 	}
 	return a.Data
 }

--- a/src/parser/atom_test.go
+++ b/src/parser/atom_test.go
@@ -94,6 +94,44 @@ func TestAtomHTMLTitle(t *testing.T) {
 	}
 }
 
+func TestAtomXHTMLTitle(t *testing.T) {
+	feed, _ := Parse(strings.NewReader(`
+		<?xml version="1.0" encoding="utf-8"?>
+		<feed xmlns="http://www.w3.org/2005/Atom">
+			<entry><title type="xhtml">say &lt;code&gt;what&lt;/code&gt;?</entry>
+		</feed>
+	`))
+	have := feed.Items[0].Title
+	want := "say what?"
+	if !reflect.DeepEqual(want, have) {
+		t.Logf("want: %#v", want)
+		t.Logf("have: %#v", have)
+		t.FailNow()
+	}
+}
+
+func TestAtomXHTMLNestedTitle(t *testing.T) {
+	feed, _ := Parse(strings.NewReader(`
+		<?xml version="1.0" encoding="utf-8"?>
+		<feed xmlns="http://www.w3.org/2005/Atom">
+			<entry>
+				<title type="xhtml">
+					<div xmlns="http://www.w3.org/1999/xhtml">
+						<a href="https://example.com">Link to Example</a>
+					</div>
+				</title>
+			</entry>
+		</feed>
+	`))
+	have := feed.Items[0].Title
+	want := "Link to Example"
+	if !reflect.DeepEqual(want, have) {
+		t.Logf("want: %#v", want)
+		t.Logf("have: %#v", have)
+		t.FailNow()
+	}
+}
+
 func TestAtomImageLink(t *testing.T) {
 	feed, _ := Parse(strings.NewReader(`
 		<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
The Atom spec says that any title marked with a type of "xhtml" should be contained in a div element[1] so we need to use the full XML text when extracting the text. This is is also compatible with feeds that don't follow the spec and just include text without the wrapping div.

I have a few feeds that follow the spec and it results in every post being called "untitled", which is not ideal.

[1] https://www.rfc-editor.org/rfc/rfc4287#section-3.1