### PR TITLE
Add GitHub action to build Docker image

### DIFF
--- a/.github/workflows/build-docker-image
+++ b/.github/workflows/build-docker-image
@@ -1,0 +1,37 @@
+name: Publish Docker Image
+on:
+  push:
+    tags: [ 'v*.*.*', 'v*.*', 'v*', 'latest' ]
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: nkanaev/yarr
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-docker-image
+++ b/.github/workflows/build-docker-image
@@ -32,6 +32,7 @@ jobs:
         uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
         with:
           context: .
+          file: ./etc/dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This is a small enhancement that will have great impact on folks running kubernetes clusters where building manually is not an easy option.

This change will simply build the Docker image and push it to GitHubs `ghcr.io` container registry for easy access any time a release is created.