### PR TITLE
Set entrypoint to yarr executable

### DIFF
--- a/etc/dockerfile
+++ b/etc/dockerfile
@@ -9,4 +9,5 @@ RUN apk add --no-cache ca-certificates && \
     update-ca-certificates
 COPY --from=build /src/_output/linux/yarr /usr/local/bin/yarr
 EXPOSE 7070
-CMD ["/usr/local/bin/yarr", "-addr", "0.0.0.0:7070", "-db", "/data/yarr.db"]
+ENTRYPOINT ["/usr/local/bin/yarr"]
+CMD ["-addr", "0.0.0.0:7070", "-db", "/data/yarr.db"]


### PR DESCRIPTION
This allows passing args as CMD directly without knowing the path to yarr within the container.

Example:
```
docker run -d yarr -addr 0.0.0.0:8080 -db /data/custom.db
```