### PR TITLE
install-linux.sh - ensure `$HOME/.local/share/{applications,icons}` dirs exist

### DIFF
--- a/etc/install-linux.sh
+++ b/etc/install-linux.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+if [[ ! -d "$HOME/.local/share/applications" ]]; then
+  mkdir -p "$HOME/.local/share/applications"
+fi
+
 cat >"$HOME/.local/share/applications/yarr.desktop" <<END
 [Desktop Entry]
 Name=yarr
@@ -8,6 +12,10 @@ Icon=yarr
 Type=Application
 Categories=Internet;
 END
+
+if [[ ! -d "$HOME/.local/share/icons" ]]; then
+  mkdir -p "$HOME/.local/share/icons"
+fi
 
 cat >"$HOME/.local/share/icons/yarr.svg" <<END
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
Tested on an Arch Linux VM: `$HOME/.local/share/applications` directory was created automatically after user creation but `$HOME/.local/share/icons` was not. As a result, second `cat` command failed when running the script.