### PR TITLE
Allow overriding the GOARCH in the makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -6,25 +6,27 @@ CGO_ENABLED=1
 GO_LDFLAGS  = -s -w
 GO_LDFLAGS := $(GO_LDFLAGS) -X 'main.Version=$(VERSION)' -X 'main.GitHash=$(GITHASH)'
 
+export GOARCH ?= amd64
+
 build_default:
 	mkdir -p _output
 	go build -tags "sqlite_foreign_keys" -ldflags="$(GO_LDFLAGS)" -o _output/yarr ./cmd/yarr
 
 build_macos:
 	mkdir -p _output/macos
-	GOOS=darwin GOARCH=amd64 go build -tags "sqlite_foreign_keys macos" -ldflags="$(GO_LDFLAGS)" -o _output/macos/yarr ./cmd/yarr
+	GOOS=darwin go build -tags "sqlite_foreign_keys macos" -ldflags="$(GO_LDFLAGS)" -o _output/macos/yarr ./cmd/yarr
 	cp src/platform/icon.png _output/macos/icon.png
 	go run ./cmd/package_macos -outdir _output/macos -version "$(VERSION)"
 
 build_linux:
 	mkdir -p _output/linux
-	GOOS=linux GOARCH=amd64 go build -tags "sqlite_foreign_keys linux" -ldflags="$(GO_LDFLAGS)" -o _output/linux/yarr ./cmd/yarr
+	GOOS=linux go build -tags "sqlite_foreign_keys linux" -ldflags="$(GO_LDFLAGS)" -o _output/linux/yarr ./cmd/yarr
 
 build_windows:
 	mkdir -p _output/windows
 	go run ./cmd/generate_versioninfo -version "$(VERSION)" -outfile src/platform/versioninfo.rc
 	windres -i src/platform/versioninfo.rc -O coff -o src/platform/versioninfo.syso
-	GOOS=windows GOARCH=amd64 go build -tags "sqlite_foreign_keys windows" -ldflags="$(GO_LDFLAGS) -H windowsgui" -o _output/windows/yarr.exe ./cmd/yarr
+	GOOS=windows go build -tags "sqlite_foreign_keys windows" -ldflags="$(GO_LDFLAGS) -H windowsgui" -o _output/windows/yarr.exe ./cmd/yarr
 
 serve:
 	go run -tags "sqlite_foreign_keys" ./cmd/yarr -db local.db


### PR DESCRIPTION
To allow for building yarr for other architectures, make the GOARCH env var overridable in the makefile.