### PR TITLE
Only read config dir if db is not provided.

### DIFF
--- a/cmd/yarr/main.go
+++ b/cmd/yarr/main.go
@@ -90,12 +90,12 @@ func main() {
 		log.SetOutput(os.Stdout)
 	}
 
-	configPath, err := os.UserConfigDir()
-	if err != nil {
-		log.Fatal("Failed to get config dir: ", err)
-	}
-
 	if db == "" {
+		configPath, err := os.UserConfigDir()
+		if err != nil {
+			log.Fatal("Failed to get config dir: ", err)
+		}
+
 		storagePath := filepath.Join(configPath, "yarr")
 		if err := os.MkdirAll(storagePath, 0755); err != nil {
 			log.Fatal("Failed to create app config dir: ", err)


### PR DESCRIPTION
Only need to read os.UserConfigDir if db is not provided.

Right now if you provide a `-db path` on command line, but $HOME or $XDG_CONFIG_HOME is not set it will error.

But that's only really needed if you don't manually specify a db.