### PR TITLE
Dockerfile: cache go build directories across builds

### DIFF
--- a/etc/dockerfile
+++ b/etc/dockerfile
@@ -2,7 +2,8 @@ FROM golang:alpine3.18 AS build
 RUN apk add build-base git
 WORKDIR /src
 COPY . .
-RUN make build_linux
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/root/go/pkg \
+  make build_linux
 
 FROM alpine:latest
 RUN apk add --no-cache ca-certificates && \


### PR DESCRIPTION
This is a small, backwards compatible improvement that allows reusing the go build and package cache across container runs. This drastically reduces build times after the first build:

First build (36s):
```
13:07:30 ~/Staging/yarr $> docker build . -f etc/dockerfile -t ghcr.io/nadiamoe/yarr
[+] Building 36.1s (14/14) FINISHED                                                                                                                                                                                      docker:default
 => [internal] load build definition from dockerfile                                                                                                                                                                               0.1s
 => => transferring dockerfile: 486B                                                                                                                                                                                               0.0s
 => [internal] load metadata for docker.io/library/golang:alpine3.18                                                                                                                                                               0.5s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                  0.1s
 => => transferring context: 2B                                                                                                                                                                                                    0.0s
 => [build 1/5] FROM docker.io/library/golang:alpine3.18@sha256:d1a601b64de09e2fa38c95e55838961811d5ca11062a8f4230a5c434b3ae2a34                                                                                                   0.0s
 => [stage-1 1/3] FROM docker.io/library/alpine:latest                                                                                                                                                                             0.0s
 => [internal] load build context                                                                                                                                                                                                  0.1s
 => => transferring context: 50.38kB                                                                                                                                                                                               0.0s
 => CACHED [build 2/5] RUN apk add build-base git                                                                                                                                                                                  0.0s
 => CACHED [build 3/5] WORKDIR /src                                                                                                                                                                                                0.0s
 => [build 4/5] COPY . .                                                                                                                                                                                                           0.3s
 => [build 5/5] RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/root/go/pkg   make build_linux                                                                                                     33.4s
 => CACHED [stage-1 2/3] RUN apk add --no-cache ca-certificates &&     update-ca-certificates                                                                                                                                      0.0s
 => [stage-1 3/3] COPY --from=build /src/_output/linux/yarr /usr/local/bin/yarr                                                                                                                                                    0.3s
 => exporting to image                                                                                                                                                                                                             1.0s
 => => exporting layers                                                                                                                                                                                                            0.9s
 => => writing image sha256:fa554988342c598f7867fe6e0db1761ebf2791cc8de99ca3b14f92b89c24b92e                                                                                                                                       0.0s
 => => naming to ghcr.io/nadiamoe/yarr                                                                                                                                                                                             0.0s
```

Subsequent build (4s):
```
13:08:25 ~/Staging/yarr $> docker build . -f etc/dockerfile -t ghcr.io/nadiamoe/yarr
[+] Building 4.0s (14/14) FINISHED                                                                                                                                                                                       docker:default
 => [internal] load build definition from dockerfile                                                                                                                                                                               0.1s
 => => transferring dockerfile: 486B                                                                                                                                                                                               0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                                                                                                   0.0s
 => [internal] load metadata for docker.io/library/golang:alpine3.18                                                                                                                                                               0.4s
 => [internal] load .dockerignore                                                                                                                                                                                                  0.0s
 => => transferring context: 2B                                                                                                                                                                                                    0.0s
 => [build 1/5] FROM docker.io/library/golang:alpine3.18@sha256:d1a601b64de09e2fa38c95e55838961811d5ca11062a8f4230a5c434b3ae2a34                                                                                                   0.0s
 => [internal] load build context                                                                                                                                                                                                  0.1s
 => => transferring context: 49.92kB                                                                                                                                                                                               0.0s
 => [stage-1 1/3] FROM docker.io/library/alpine:latest                                                                                                                                                                             0.0s
 => CACHED [build 2/5] RUN apk add build-base git                                                                                                                                                                                  0.0s
 => CACHED [build 3/5] WORKDIR /src                                                                                                                                                                                                0.0s
 => [build 4/5] COPY . .                                                                                                                                                                                                           0.8s
 => [build 5/5] RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/root/go/pkg   make build_linux                                                                                                      1.2s
 => CACHED [stage-1 2/3] RUN apk add --no-cache ca-certificates &&     update-ca-certificates                                                                                                                                      0.0s
 => [stage-1 3/3] COPY --from=build /src/_output/linux/yarr /usr/local/bin/yarr                                                                                                                                                    0.2s
 => exporting to image                                                                                                                                                                                                             0.8s
 => => exporting layers                                                                                                                                                                                                            0.8s
 => => writing image sha256:cb56047ebd0c9dfdfdf48a7a879b6c6b293c3fc3236e2f471b703d06f1fb75b6                                                                                                                                       0.0s
 => => naming to ghcr.io/nadiamoe/yarr                                                                                                                                                                                             0.0s
```