### PR TITLE
Listen on AF_UNIX socket if -addr is a path

### DIFF
--- a/cmd/yarr/main.go
+++ b/cmd/yarr/main.go
@@ -90,6 +90,10 @@ func main() {
 		log.SetOutput(os.Stdout)
 	}
 
+	if open && strings.HasPrefix(addr, "unix:") {
+		log.Fatal("Cannot open ", addr, " in browser")
+	}
+
 	if db == "" {
 		configPath, err := os.UserConfigDir()
 		if err != nil {


### PR DESCRIPTION
I'm running yarr behind a reverse proxy, so don't need it to listen on a TCP port.