### PR TITLE
Adds Support for ARM64 Docker Images

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -38,3 +38,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
PR updates the build-docker workflow to add suport for ARM64 images.

Testing
=======

Locally, I attempted to build an image from the provided Dockerfile in an ARM64 host using:

```sh
podman build -t yarr:latest -f etc/dockerfile .
```

The `platforms` input is provided as documented in [1].

1 - https://github.com/docker/build-push-action?tab=readme-ov-file#inputs