### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/src/platform/open_etc.go
+++ b/src/platform/open_etc.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux || freebsd
 
 package platform
 


### PR DESCRIPTION
I'm maintaining yarr in the FreeBSD portstree and had to apply a small build fix to 2.5 that I'm upstreaming here now.

https://codeberg.org/FreeBSD/freebsd-ports/commit/996a1055dfb79571671cd647b87d3021a08d3b0d