### PR TITLE
Add more categories to desktop shortcut

### DIFF
--- a/etc/install-linux.sh
+++ b/etc/install-linux.sh
@@ -10,7 +10,7 @@ Name=yarr
 Exec=$HOME/.local/bin/yarr -open
 Icon=yarr
 Type=Application
-Categories=Internet;
+Categories=Internet;Network;News;Feed;
 END
 
 if [[ ! -d "$HOME/.local/share/icons" ]]; then


### PR DESCRIPTION
Ensures that it doesn't end up in "Lost & Found" on KDE Plasma's "Applications" menu. Just having "Internet" alone causes it to end up in "Lost & Found" instead of the "Internet" category of the applications menu.