### PR TITLE
fever: parse multi-part form data in addition to form data

### DIFF
--- a/src/server/fever.go
+++ b/src/server/fever.go
@@ -95,7 +95,7 @@ func formHasValue(values url.Values, value string) bool {
 }
 
 func (s *Server) handleFever(c *router.Context) {
-	c.Req.ParseForm()
+	c.Req.ParseMultipartForm(1 << 20) // Read up to 1MiB max.
 	if !s.feverAuth(c) {
 		c.JSON(http.StatusOK, map[string]interface{}{
 			"api_version":            3,


### PR DESCRIPTION
This PR fixes a compatibility issue with the [Readrops](https://f-droid.org/en/packages/com.readrops.app/) android RSS client, which supports the Fever API.

Readrops sends the password hash as multipart form data in HTTP requests (for reasons unknown to me). This was not playing well with yarr's code, due to an annoying interaction of how Go's `http.Request.GetFormValue` and the Fever API. `GetFormValue` will skip parsing any multipart form data if `r.Form != nil`. As the Fever API mandates the GET parameter `?api` to be present in the request, this falses that condition, and as a result the multipart form data is never parsed for Fever API requests.

This PR changes the Fever API code so it attempts to parse multipart form data in addition to regular form data.

This was enough to get me past the authentication screen on Readrops.

cc @icefed as requested in `fever.md`.