### PR TITLE
fix media_links reading from DB

### DIFF
--- a/src/storage/item.go
+++ b/src/storage/item.go
@@ -54,10 +54,14 @@ type MediaLink struct {
 type MediaLinks []MediaLink
 
 func (m *MediaLinks) Scan(src any) error {
-	if data, ok := src.([]byte); ok {
+	switch data := src.(type) {
+	case []byte:
 		return json.Unmarshal(data, m)
+	case string:
+		return json.Unmarshal([]byte(data), m)
+	default:
+		return nil
 	}
-	return nil
 }
 
 func (m MediaLinks) Value() (driver.Value, error) {
@@ -419,7 +423,6 @@ func (s *Storage) DeleteOldItems() {
 		where status != ?
 		group by i.feed_id
 	`, itemsKeepSize, STARRED)
-
 	if err != nil {
 		log.Print(err)
 		return


### PR DESCRIPTION
Prior to this commit, `media_links` for items were always returned as `nil`. Peeking a bit I figured that's becuase the argument to `MediaLinks.Scan` is in fact a string, and not a `[]byte` as the code expects. I guess that might be because `media_links` is a `json` (not `jsonb`) column in sqlite. I have no idea which of the two is best to use for the DB side, but it's easy to make the code support both.