### PR TITLE
Allow to show feed image preview

### DIFF
--- a/src/assets/index.html
+++ b/src/assets/index.html
@@ -76,6 +76,14 @@
 
                     <div class="dropdown-divider"></div>
 
+                    <header class="dropdown-header" role="heading" aria-level="2">Feed item image preview</header>
+                    <div class="row text-center m-0">
+                        <button class="dropdown-item px-0" :aria-pressed="itemShowImagePreview"  :class="{active: itemShowImagePreview}"  @click.stop="itemShowImagePreview=true">Show</button>
+                        <button class="dropdown-item px-0" :aria-pressed="!itemShowImagePreview" :class="{active: !itemShowImagePreview}" @click.stop="itemShowImagePreview=false">Hide</button>
+                    </div>
+
+                    <div class="dropdown-divider"></div>
+
                     <header class="dropdown-header" role="heading" aria-level="2">Auto Refresh</header>
                     <div class="row text-center m-0">
                         <button class="dropdown-item col-4 px-0" :aria-pressed="!refreshRate"       :class="{active: !refreshRate}"       @click.stop="refreshRate = 0">0</button>
@@ -287,6 +295,7 @@
                             </small>
                             <small class="flex-shrink-0"><relative-time v-bind:title="formatDate(item.date)" :val="item.date"/></small>
                         </div>
+                        <img v-if="itemShowImagePreview && feedItemImage(item)" :src="feedItemImage(item)" style="border-radius: 4px;">
                         <div>{{ item.title || 'untitled' }}</div>
                     </div>
                 </label>

--- a/src/parser/feed.go
+++ b/src/parser/feed.go
@@ -137,6 +137,13 @@ func (feed *Feed) cleanup() {
 		if len(feed.Items[i].MediaLinks) > 0 {
 			mediaLinks := make([]MediaLink, 0)
 			for _, link := range item.MediaLinks {
+				// Keep image media links even if they appear on the feed content.
+				// They will be used to display a feed image preview and will be removed on the feed details on the frontend.
+				if link.Type == "image" {
+					mediaLinks = append(mediaLinks, link)
+					continue
+				}
+
 				if !strings.Contains(item.Content, link.URL) {
 					mediaLinks = append(mediaLinks, link)
 				}

--- a/src/parser/json.go
+++ b/src/parser/json.go
@@ -3,7 +3,9 @@ package parser
 
 import (
 	"encoding/json"
+	"html"
 	"io"
+	"strings"
 )
 
 type jsonFeed struct {
@@ -45,12 +47,34 @@ func ParseJSON(data io.Reader) (*Feed, error) {
 		SiteURL: srcfeed.SiteURL,
 	}
 	for _, srcitem := range srcfeed.Items {
+		mediaLinks := []MediaLink{}
+
+		for _, e := range srcitem.Attachments {
+			if strings.HasPrefix(e.MimeType, "image/") {
+				mediaLinks = append(mediaLinks, MediaLink{URL: e.URL, Type: "image"})
+			}
+		}
+
+		if isLinkPossiblyAImage(srcitem.URL) {
+			mediaLinks = append(mediaLinks, MediaLink{URL: srcitem.URL, Type: "image"})
+		}
+
+		content := firstNonEmpty(srcitem.HTML, srcitem.Text, srcitem.Summary)
+		if contentImage := findImageInContent(html.UnescapeString(content)); contentImage != nil {
+			mediaLinks = append(mediaLinks, MediaLink{URL: *contentImage, Type: "image"})
+		}
+
+		if len(mediaLinks) <= 0 {
+			mediaLinks = nil
+		}
+
 		dstfeed.Items = append(dstfeed.Items, Item{
-			GUID:    firstNonEmpty(srcitem.ID, srcitem.URL),
-			Date:    dateParse(firstNonEmpty(srcitem.DatePublished, srcitem.DateModified)),
-			URL:     srcitem.URL,
-			Title:   srcitem.Title,
-			Content: firstNonEmpty(srcitem.HTML, srcitem.Text, srcitem.Summary),
+			GUID:       firstNonEmpty(srcitem.ID, srcitem.URL),
+			Date:       dateParse(firstNonEmpty(srcitem.DatePublished, srcitem.DateModified)),
+			URL:        srcitem.URL,
+			Title:      srcitem.Title,
+			Content:    content,
+			MediaLinks: mediaLinks,
 		})
 	}
 	return dstfeed, nil

--- a/src/parser/json_test.go
+++ b/src/parser/json_test.go
@@ -40,3 +40,83 @@ func TestJSONFeed(t *testing.T) {
 		t.Fatal("invalid json")
 	}
 }
+
+func TestJSONFeedItemAttachementsHasImage(t *testing.T) {
+	feed, _ := Parse(strings.NewReader(`{
+		"items": [
+			{
+				"attachments": [
+					{
+						"url": "http://example.org/image",
+						"mime_type": "image/png"
+					}
+				]
+			}
+		]
+	}`))
+
+	have := feed.Items[0].MediaLinks
+	want := []MediaLink{
+		MediaLink{
+			URL:         "http://example.org/image",
+			Type:        "image",
+			Description: "",
+		},
+	}
+
+	if !reflect.DeepEqual(want, have) {
+		t.Logf("want: %#v", want)
+		t.Logf("have: %#v", have)
+		t.Fatal("invalid json")
+	}
+}
+
+func TestJSONFeedItemLinkIsImage(t *testing.T) {
+	feed, _ := Parse(strings.NewReader(`{
+		"items": [
+			{
+				"url": "http://example.org/image.jpg"
+			}
+		]
+	}`))
+
+	have := feed.Items[0].MediaLinks
+	want := []MediaLink{
+		MediaLink{
+			URL:         "http://example.org/image.jpg",
+			Type:        "image",
+			Description: "",
+		},
+	}
+
+	if !reflect.DeepEqual(want, have) {
+		t.Logf("want: %#v", want)
+		t.Logf("have: %#v", have)
+		t.Fatal("invalid json")
+	}
+}
+
+func TestJSONFeedItemContentHasImage(t *testing.T) {
+	feed, _ := Parse(strings.NewReader(`{
+		"items": [
+			{
+				"content_html": "<p>foobar</p> <img src=\"http://example.org/image\" />"
+			}
+		]
+	}`))
+
+	have := feed.Items[0].MediaLinks
+	want := []MediaLink{
+		MediaLink{
+			URL:         "http://example.org/image",
+			Type:        "image",
+			Description: "",
+		},
+	}
+
+	if !reflect.DeepEqual(want, have) {
+		t.Logf("want: %#v", want)
+		t.Logf("have: %#v", have)
+		t.Fatal("invalid json")
+	}
+}

--- a/src/parser/media.go
+++ b/src/parser/media.go
@@ -1,8 +1,36 @@
 package parser
 
 import (
+	"regexp"
 	"strings"
 )
+
+var webImageFileExtensions = []string{
+	// APNG
+	".apng",
+
+	// AVIF
+	".avif",
+
+	// GIF
+	".gif",
+
+	// JPEG
+	".jpg",
+	".jpeg",
+	".jfif",
+	".pjpeg",
+	".pjp",
+
+	// PNG
+	".png",
+
+	// SVG
+	".svg",
+
+	// WebP
+	".webp",
+}
 
 type media struct {
 	MediaGroups       []mediaGroup       `xml:"http://search.yahoo.com/mrss/ group"`
@@ -32,6 +60,26 @@ type mediaThumbnail struct {
 type mediaDescription struct {
 	Type string `xml:"type,attr"`
 	Text string `xml:",chardata"`
+}
+
+func isLinkPossiblyAImage(link string) bool {
+	link = strings.ToLower(link)
+	for _, ext := range webImageFileExtensions {
+		if strings.Contains(link, ext) {
+			return true
+		}
+	}
+	return false
+}
+
+func findImageInContent(content string) *string {
+	r := regexp.MustCompile(`(?i)(?m)<img[^>]+src=["']([^"']+)["']`)
+	match := r.FindStringSubmatch(content)
+
+	if len(match) > 1 {
+		return &match[1]
+	}
+	return nil
 }
 
 func (m *media) firstMediaThumbnail() string {

--- a/src/parser/rdf_test.go
+++ b/src/parser/rdf_test.go
@@ -79,3 +79,59 @@ func TestRDFExtensions(t *testing.T) {
 		t.FailNow()
 	}
 }
+
+func TestRDFFeedItemLinkIsImage(t *testing.T) {
+	feed, _ := Parse(strings.NewReader(`
+		<?xml version="1.0" encoding="utf-8"?>
+		<rdf:RDF xmlns="http://purl.org/rss/1.0/"
+				xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+				xmlns:dc="http://purl.org/dc/elements/1.1/"
+				xmlns:content="http://purl.org/rss/1.0/modules/content/">
+			<item>
+				<link>http://example.com/image.gif</link>
+			</item>
+		</rdf:RDF>
+	`))
+
+	have := feed.Items[0].MediaLinks
+	want := []MediaLink{
+		MediaLink{
+			URL:         "http://example.com/image.gif",
+			Type:        "image",
+			Description: "",
+		},
+	}
+	if !reflect.DeepEqual(want, have) {
+		t.Logf("want: %#v", want)
+		t.Logf("have: %#v", have)
+		t.FailNow()
+	}
+}
+
+func TestRDFFeedItemContentHasImage(t *testing.T) {
+	feed, _ := Parse(strings.NewReader(`
+		<?xml version="1.0" encoding="utf-8"?>
+		<rdf:RDF xmlns="http://purl.org/rss/1.0/"
+				xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+				xmlns:dc="http://purl.org/dc/elements/1.1/"
+				xmlns:content="http://purl.org/rss/1.0/modules/content/">
+			<item>
+				<content:encoded><![CDATA[<p>foo</p> <img src="http://example.com/image" />]]></content:encoded>
+			</item>
+		</rdf:RDF>
+	`))
+
+	have := feed.Items[0].MediaLinks
+	want := []MediaLink{
+		MediaLink{
+			URL:         "http://example.com/image",
+			Type:        "image",
+			Description: "",
+		},
+	}
+	if !reflect.DeepEqual(want, have) {
+		t.Logf("want: %#v", want)
+		t.Logf("have: %#v", have)
+		t.FailNow()
+	}
+}

--- a/src/parser/rss_test.go
+++ b/src/parser/rss_test.go
@@ -286,3 +286,84 @@ func TestRSSMultipleMedia(t *testing.T) {
 		t.Fatal("invalid rss")
 	}
 }
+
+func TestRSSItemEnclosureHasImage(t *testing.T) {
+	feed, _ := Parse(strings.NewReader(`
+		<?xml version="1.0" encoding="UTF-8"?>
+		<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+			<channel>
+				<item>
+					<enclosure url="http://example.org/image" length="123456" type="image/jpeg" />
+				</item>
+			</channel>
+		</rss>
+	`))
+	have := feed.Items[0].MediaLinks
+	want := []MediaLink{
+		MediaLink{
+			URL:         "http://example.org/image",
+			Type:        "image",
+			Description: "",
+		},
+	}
+	if !reflect.DeepEqual(want, have) {
+		t.Logf("want: %#v", want)
+		t.Logf("have: %#v", have)
+		t.Fatal("invalid rss")
+	}
+}
+
+func TestRSSItemLinkIsImage(t *testing.T) {
+	feed, _ := Parse(strings.NewReader(`
+		<?xml version="1.0" encoding="UTF-8"?>
+		<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+			<channel>
+				<item>
+					<link>http://example.org/image.png</link>
+				</item>
+			</channel>
+		</rss>
+	`))
+	have := feed.Items[0].MediaLinks
+	want := []MediaLink{
+		MediaLink{
+			URL:         "http://example.org/image.png",
+			Type:        "image",
+			Description: "",
+		},
+	}
+	if !reflect.DeepEqual(want, have) {
+		t.Logf("want: %#v", want)
+		t.Logf("have: %#v", have)
+		t.Fatal("invalid rss")
+	}
+}
+
+func TestRSSItemContentHasImage(t *testing.T) {
+	feed, _ := Parse(strings.NewReader(`
+		<?xml version="1.0" encoding="UTF-8"?>
+		<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+			<channel>
+				<item>
+					<content:encoded><![CDATA[
+			        <p>foo</p>
+			        <img src="http://example.org/image" alt="Sample Image" />
+			      ]]></content:encoded>
+				</item>
+			</channel>
+		</rss>
+	`))
+	have := feed.Items[0].MediaLinks
+	want := []MediaLink{
+		MediaLink{
+			URL:         "http://example.org/image",
+			Type:        "image",
+			Description: "",
+		},
+	}
+	if !reflect.DeepEqual(want, have) {
+		t.Logf("want: %#v", want)
+		t.Logf("have: %#v", have)
+		t.Fatal("invalid rss")
+	}
+}

--- a/src/storage/settings.go
+++ b/src/storage/settings.go
@@ -7,15 +7,16 @@ import (
 
 func settingsDefaults() map[string]interface{} {
 	return map[string]interface{}{
-		"filter":            "",
-		"feed":              "",
-		"feed_list_width":   300,
-		"item_list_width":   300,
-		"sort_newest_first": true,
-		"theme_name":        "light",
-		"theme_font":        "",
-		"theme_size":        1,
-		"refresh_rate":      0,
+		"filter":             "",
+		"feed":               "",
+		"feed_list_width":    300,
+		"item_list_width":    300,
+		"sort_newest_first":  true,
+		"theme_name":         "light",
+		"theme_font":         "",
+		"theme_size":         1,
+		"refresh_rate":       0,
+		"item_image_preview": false,
 	}
 }
 


### PR DESCRIPTION
It follows the following logic:
  - check if we have any enclosure/attachments with type image
  - check for the feed item link itself if it has a image file extension
  - check the feed item content for any img tags

On the frontend we get the first medialink that is of type image.
The dedup code to remove media link contained in the feed item content itself was moved to the frontend in order to have image media links that can be used to dhow a feed image.

Closes:
 - https://github.com/nkanaev/yarr/issues/263