### PR TITLE
fix reset content panels and set loading state when navigating feeds and filters

### DIFF
--- a/src/assets/index.html
+++ b/src/assets/index.html
@@ -28,21 +28,21 @@
                         :class="{active: filterSelected == 'unread'}"
                         :aria-pressed="filterSelected == 'unread'"
                         title="Unread"
-                        @click="filterSelected = 'unread'">
+                        @click="filterSelected = 'unread'; selectFilter()">
                     <span class="icon">{% inline "circle-full.svg" %}</span>
                 </button>
                 <button class="toolbar-item mx-1"
                         :class="{active: filterSelected == 'starred'}"
                         :aria-pressed="filterSelected == 'starred'"
                         title="Starred"
-                        @click="filterSelected = 'starred'">
+                        @click="filterSelected = 'starred'; selectFilter()">
                     <span class="icon">{% inline "star-full.svg" %}</span>
                 </button>
                 <button class="toolbar-item mr-1"
                         :class="{active: filterSelected == ''}"
                         :aria-pressed="filterSelected == ''"
                         title="All"
-                        @click="filterSelected = ''">
+                        @click="filterSelected = ''; selectFilter()">
                     <span class="icon">{% inline "assorted.svg" %}</span>
                 </button>
                 <div class="flex-grow-1"></div>
@@ -133,7 +133,7 @@
             </div>
             <div id="feed-list-scroll" class="p-2 overflow-auto scroll-touch border-top flex-grow-1">
                 <label class="selectgroup">
-                    <input type="radio" name="feed" value="" v-model="feedSelected">
+                    <input type="radio" name="feed" value="" v-model="feedSelected" @change="selectFeed()">
                     <div class="selectgroup-label d-flex align-items-center w-100">
                         <span class="icon mr-2">{% inline "layers.svg" %}</span>
                         <span class="flex-fill text-left text-truncate" v-if="filterSelected=='unread'">All Unread</span>
@@ -146,7 +146,7 @@
                     <label class="selectgroup mt-1"
                            :class="{'d-none': mustHideFolder(folder)}"
                            v-if="folder.id">
-                        <input type="radio" name="feed" :value="'folder:'+folder.id" v-model="feedSelected" v-if="folder.id">
+                        <input type="radio" name="feed" :value="'folder:'+folder.id" v-model="feedSelected" @change="selectFeed()" v-if="folder.id">
                         <div class="selectgroup-label d-flex align-items-center w-100" v-if="folder.id">
                             <span class="icon mr-2"
                                   :class="{expanded: folder.is_expanded}"
@@ -161,7 +161,7 @@
                         <label class="selectgroup"
                               :class="{'d-none': mustHideFeed(feed)}"
                                v-for="feed in folder.feeds">
-                            <input type="radio" name="feed" :value="'feed:'+feed.id" v-model="feedSelected">
+                            <input type="radio" name="feed" :value="'feed:'+feed.id" v-model="feedSelected" @change="selectFeed()">
                             <div class="selectgroup-label d-flex align-items-center w-100">
                                 <span class="icon mr-2" v-if="!feed.has_icon">{% inline "rss.svg" %}</span>
                                 <span class="icon mr-2" v-else><img :src="'./api/feeds/'+feed.id+'/icon'" alt="" loading="lazy"></span>
@@ -187,7 +187,7 @@
             <drag :width="itemListWidth" @resize="resizeItemList"></drag>
             <div class="px-2 toolbar d-flex align-items-center">
                 <button class="toolbar-item mr-2 d-block d-md-none"
-                        @click="feedSelected = null"
+                        @click="feedSelected = null; selectFeed()"
                         title="Show Feeds">
                     <span class="icon">{% inline "chevron-left.svg" %}</span>
                 </button>
@@ -358,7 +358,7 @@
                     <h1><b>{{ itemSelectedDetails.title || 'untitled' }}</b></h1>
                     <div class="text-muted">
                         <div>
-                            <span class="cursor-pointer" @click="feedSelected = 'feed:'+(feedsById[itemSelectedDetails.feed_id] || {}).id">
+                            <span class="cursor-pointer" @click="feedSelected = 'feed:'+(feedsById[itemSelectedDetails.feed_id] || {}).id; selectFeed()">
                                 {{ (feedsById[itemSelectedDetails.feed_id] || {}).title }}
                             </span>
                         </div>

--- a/src/assets/javascripts/app.js
+++ b/src/assets/javascripts/app.js
@@ -579,6 +579,7 @@ var vm = new Vue({
       if (confirm('Are you sure you want to delete ' + folder.title + '?')) {
         api.folders.delete(folder.id).then(function() {
           vm.feedSelected = null
+          vm.selectFeed()
           vm.refreshStats()
           vm.refreshFeeds()
         })
@@ -604,6 +605,7 @@ var vm = new Vue({
       if (confirm('Are you sure you want to delete ' + feed.title + '?')) {
         api.feeds.delete(feed.id).then(function() {
           vm.feedSelected = null
+          vm.selectFeed()
           vm.refreshStats()
           vm.refreshFeeds()
         })
@@ -625,6 +627,7 @@ var vm = new Vue({
           vm.refreshStats()
           vm.settings = ''
           vm.feedSelected = 'feed:' + result.feed.id
+          vm.selectFeed()
         } else if (result.status === 'multiple') {
           vm.feedNewChoice = result.choice
           vm.feedNewChoiceSelected = result.choice[0].url
@@ -795,6 +798,7 @@ var vm = new Vue({
 
       if (currentFeedPosition == -1) {
         vm.feedSelected = ''
+        vm.selectFeed()
         return
       }
 
@@ -802,6 +806,7 @@ var vm = new Vue({
       if (newPosition < 0 || newPosition >= navigationList.length) return
 
       vm.feedSelected = navigationList[newPosition]
+      vm.selectFeed()
 
       vm.$nextTick(function() {
         var scroll = document.querySelector('#feed-list-scroll')
@@ -829,6 +834,16 @@ var vm = new Vue({
         && !(this.current.feed.id == feed.id)
         && !this.filteredFeedStats[feed.id]
         && (!this.itemSelectedDetails || this.itemSelectedDetails.feed_id != feed.id)
+    },
+    selectFeed: function() {
+      this.itemSelected = null
+      this.items.length = 0
+      this.itemsHasMore = true
+    },
+    selectFilter: function() {
+      this.itemSelected = null
+      this.items.length = 0
+      this.itemsHasMore = true
     },
   }
 })

--- a/src/assets/javascripts/key.js
+++ b/src/assets/javascripts/key.js
@@ -65,12 +65,15 @@ var shortcutFunctions = {
   },
   showAll() {
     vm.filterSelected = ''
+    vm.selectFilter()
   },
   showUnread() {
     vm.filterSelected = 'unread'
+    vm.selectFilter()
   },
   showStarred() {
     vm.filterSelected = 'starred'
+    vm.selectFilter()
   },
 }
 


### PR DESCRIPTION
whenever you click a feed/folder or a filter (all, starred, unread) the column of items does not clears instantly nor a loading spinner shows. this PR fixes it