### PR TITLE
Add option to refresh feeds weekly

### DIFF
--- a/src/assets/javascripts/app.js
+++ b/src/assets/javascripts/app.js
@@ -268,6 +268,7 @@ var vm = new Vue({
         { title: "4h", value: 240 },
         { title: "12h", value: 720 },
         { title: "24h", value: 1440 },
+        { title: "7d", value: 10080 },
       ],
     }
   },


### PR DESCRIPTION
Hello there! I have read #57, and I was wondering if this change would be a small enough improvement to be acceptable.

One can configure any refresh time via the database, but the UI will display `0` for any non-default number. Adding support for custom values would be a larger change. This commit introduces a single, relatively common refresh schedule: every 7 days. Perfect for a "slow web" approach to news, or catching up during the weekend.

The label could read either `7d` or `1w`, I thought the former would be more obvious.

Thank you!