### PR TITLE
fix: add QEMU and Buildx setup for multi-arch Docker builds

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -3,6 +3,8 @@ on:
   push:
     tags:
       - v*
+  workflow_dispatch:
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: nkanaev/yarr


### PR DESCRIPTION
Fixes #290

The workflow was failing because it specified multi-platform builds (linux/amd64,linux/arm64) but didn't set up QEMU emulation or Buildx.

This adds the required setup steps before the build action.