### PR TITLE
routes(handleManifest): implement PWA requirement of both 192x and 512x

### DIFF
--- a/src/server/routes.go
+++ b/src/server/routes.go
@@ -94,6 +94,16 @@ func (s *Server) handleManifest(c *router.Context) {
 				"sizes": "64x64",
 				"type":  "image/png",
 			},
+			{
+				"src":   s.BasePath + "/static/graphicarts/favicon.png",
+				"sizes": "192x192",
+				"type":  "image/png",
+			},
+			{
+				"src":   s.BasePath + "/static/graphicarts/favicon.png",
+				"sizes": "512x512",
+				"type":  "image/png",
+			},
 		},
 	})
 }


### PR DESCRIPTION
Closes #292

icons in the manifest.json

Tested on Firefox for Android.

Reference: https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Guides/Making_PWAs_installable#the_web_app_manifest