### PR TITLE
Fever handle root folder

### DIFF
--- a/src/server/fever.go
+++ b/src/server/fever.go
@@ -367,7 +367,7 @@ func (s *Server) feverMarkHandler(c *router.Context) {
 		markFilter := storage.MarkFilter{FeedID: &id}
 		x, _ := strconv.ParseInt(c.Req.Form.Get("before"), 10, 64)
 		if x > 0 {
-			before := time.Unix(x, 0)
+			before := time.Unix(x, 0).UTC()
 			markFilter.Before = &before
 		}
 		s.db.MarkItemsRead(markFilter)
@@ -378,7 +378,7 @@ func (s *Server) feverMarkHandler(c *router.Context) {
 		markFilter := storage.MarkFilter{FolderID: &id}
 		x, _ := strconv.ParseInt(c.Req.Form.Get("before"), 10, 64)
 		if x > 0 {
-			before := time.Unix(x, 0)
+			before := time.Unix(x, 0).UTC()
 			markFilter.Before = &before
 		}
 		s.db.MarkItemsRead(markFilter)

--- a/src/server/fever.go
+++ b/src/server/fever.go
@@ -375,7 +375,10 @@ func (s *Server) feverMarkHandler(c *router.Context) {
 		if c.Req.Form.Get("as") != "read" {
 			c.Out.WriteHeader(http.StatusBadRequest)
 		}
-		markFilter := storage.MarkFilter{FolderID: &id}
+		markFilter := storage.MarkFilter{}
+		if id > 0 {
+			markFilter.FolderID = &id
+		} 
 		x, _ := strconv.ParseInt(c.Req.Form.Get("before"), 10, 64)
 		if x > 0 {
 			before := time.Unix(x, 0).UTC()


### PR DESCRIPTION
Reeder (over Fever) is passing id=0 when you Mark All as Read, but that means avoiding adding a folder filter, otherwise only Folder 0 will get marked (feeds in no folder).