### PR TITLE
Storage: Fix timezone-sensitive date filtering in sqlite

### DIFF
--- a/src/storage/sqlite/item.go
+++ b/src/storage/sqlite/item.go
@@ -87,6 +87,10 @@ func (s *SQLiteStorage) CreateItems(items []model.Item) bool {
 	return true
 }
 
+func sqliteDate(t time.Time) string {
+	return t.UTC().Format("2006-01-02 15:04:05.000")
+}
+
 func listQueryPredicate(filter model.ItemFilter, newestFirst bool) (string, []any) {
 	cond := make([]string, 0)
 	args := make([]any, 0)
@@ -148,7 +152,7 @@ func listQueryPredicate(filter model.ItemFilter, newestFirst bool) (string, []an
 	}
 	if filter.Before != nil {
 		cond = append(cond, "i.date < :before")
-		args = append(args, sql.Named("before", filter.Before))
+		args = append(args, sql.Named("before", sqliteDate(*filter.Before)))
 	}
 
 	predicate := "1"

--- a/src/storage/tests/item_test.go
+++ b/src/storage/tests/item_test.go
@@ -281,6 +281,30 @@ func TestListItemsPaginated(t *testing.T) {
 	})
 }
 
+func TestListItemsDateBoundsTimezone(t *testing.T) {
+	dbtest(t, func(t *testing.T, db storage.Storage) {
+		testItemsSetup(db)
+
+		itemsByGUID := make(map[string]model.Item)
+		for _, item := range db.ListItems(model.ItemFilter{}, 1000, false, false) {
+			itemsByGUID[item.GUID] = item
+		}
+		bound := MustGet(itemsByGUID, "item121").Date
+		elsewhere := bound.In(time.FixedZone("X", -7*3600))
+
+		want := getItemGuids(db.ListItems(model.ItemFilter{Before: &bound}, 20, false, false))
+		have := getItemGuids(db.ListItems(model.ItemFilter{Before: &elsewhere}, 20, false, false))
+		if len(want) == 0 {
+			t.Fatalf("fixture produced an empty result; the test proves nothing")
+		}
+		if !reflect.DeepEqual(have, want) {
+			t.Logf("want: %#v", want)
+			t.Logf("have: %#v", have)
+			t.Fail()
+		}
+	})
+}
+
 func TestMarkAllItemsRead(t *testing.T) {
 	var read model.ItemStatus = model.READ
 	dbtest(t, func(t *testing.T, db storage.Storage) {


### PR DESCRIPTION
CreateItems stores dates as UTC text via strftime, and the ItemFilter.Before comparison is a plain string compare, so binding a time.Time in any other location compared its local clock reading and silently selected the wrong rows.

This affects the Fever API, which passes a client-supplied "before" timestamp, and /api/items. Normalize the bound to the stored format instead.